### PR TITLE
fix: Fix some build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,21 +1,26 @@
+```
 ╔╗░╔╗░░╔╗╔╗░░░░╔╗╔╗╔╗░░░░╔╗░░╔╗
 ║║░║║░░║║║║░░░░║║║║║║░░░░║║░░║║
 ║╚═╝╠══╣║║║╔══╗║║║║║╠══╦═╣║╔═╝║
 ║╔═╗║║═╣║║║║╔╗║║╚╝╚╝║╔╗║╔╣║║╔╗║
 ║║░║║║═╣╚╣╚╣╚╝║╚╗╔╗╔╣╚╝║║║╚╣╚╝║
 ╚╝░╚╩══╩═╩═╩══╝░╚╝╚╝╚══╩╝╚═╩══╝
+```
 
+# Compiling and running
 
-#Compiling
+## x86 assembly:
+1. `nasm -f elf32 hello-world.asm`
+2. `gcc -m32 -o hello hello-world.o`
+3. `./hello`
 
 ## C language:
-1. gcc hello-world.c -o hello
-2. ./hello 
+1. `gcc hello-world.c -o hello`
+2. `./hello`
 
-## CPP :
-1. g++ hello-world.c -o hello
-2. ./hello 
+## C++:
+1. `g++ hello-world.c -o hello`
+2. `./hello`
 
-## Python :
-1. python hello-world.py
-
+## Python:
+1. `python hello-world.py`

--- a/hello-world.asm
+++ b/hello-world.asm
@@ -2,8 +2,8 @@
 ; Simple NASM syntax assembly program for x86 (32 bit).
 ;
 ; Use commands below to assemble, link and run ($ is the prompt):
-; $ nasm -f elf32 hello.asm
-; $ gcc -m32 -o hello hello.o
+; $ nasm -f elf32 hello-world.asm
+; $ gcc -m32 -o hello hello-world.o
 ; $ ./hello
 ; Hello, world!
 ;


### PR DESCRIPTION
Fixes markup of BUILDING.md. Currently the header / title looks pretty broken:
![screenshot 2018-10-30 at 11 05 14](https://user-images.githubusercontent.com/1408377/47710715-bf8e0a80-dc33-11e8-8664-c3af5a56f3cb.png)

Also removes some trailing whitespaces and clarify that the instructions also cover running and fixed / added the x86 assembly instructions.